### PR TITLE
Geojson-vt with Mapbox behind the scene

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,1 @@
+Folder to store test data

--- a/vib/static/common.css
+++ b/vib/static/common.css
@@ -13,4 +13,6 @@ body {
 .vib-layerid {
   padding: 6px;
 }
-
+#gl-hover {
+  opacity: 0.5;
+}

--- a/vib/static/glmap.js
+++ b/vib/static/glmap.js
@@ -118,6 +118,56 @@
     return addBackground(map, layerId);
   }
 
+  function geojsonDragAndDrop(map) {
+    // Mapbox GL JS uses geojson-vt behind the scene
+    // https://www.mapbox.com/blog/introducing-geojson-vt/
+    // Only support Linestring for the demo
+    var canvas = map.getCanvas();
+    canvas.ondragover = function() {
+      this.id = 'gl-hover';
+      return false;
+    };
+    canvas.ondragend = function() {
+      this.id = '';
+      return false;
+    };
+    canvas.onmouseout = function() {
+      this.id = '';
+    };
+    canvas.ondrop = function(e) {
+      var that = this;
+      var reader = new FileReader();
+      var filename = e.dataTransfer.files[0].name;
+      reader.onload = function(event) {
+        var data = JSON.parse(event.target.result);
+        map.addLayer({
+          "id": filename,
+          "type": "line",
+          "source": {
+            "type": "geojson",
+            "data": data
+          },
+          "layout": {
+            "line-join": "round",
+            "line-cap": "round"
+          },
+          "paint": {
+            "line-color": "aquamarine",
+            "line-width": 2
+          }
+        });
+        that.id = '';
+      };
+      reader.onerror = function() {
+        that.id = '';
+      };
+      reader.readAsText(e.dataTransfer.files[0]);
+
+      e.preventDefault();
+      return false;
+    };
+  }
+
   function initMap() {
     mapboxgl.accessToken = 'pk.eyJ1IjoidmliMmQiLCJhIjoiY2l5eTlqcGtoMDAwZzJ3cG56' +
         'emF6YmRoOCJ9.lP3KfJVHrUHp7DXIQrZYMw';
@@ -140,6 +190,8 @@
       if (app.params.lang && app.params.lang != 'all') {
         changeMapLang(map, app.params.lang);
       }
+      // Attach drag and drop listener
+      geojsonDragAndDrop(map);
     });
 
     map.on('moveend', function(e) {
@@ -178,8 +230,8 @@
       //stop and alert user map is not supported
       alert('Your browser does not support Mapbox GL.  Please try Chrome or Firefox.');
     }
-    var map = initMap();
 
+    var map = initMap();
     // Handle languages
     var selectedLang = $('.vib-langselector option[value=' + app.params.lang + ']');
     if (selectedLang) {

--- a/vib/templates/glmap.html
+++ b/vib/templates/glmap.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet prefetch" href="https://api.mapbox.com/mapbox-gl-js/v0.34.0/mapbox-gl.css">
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet prefetch" href="static/glmap.css">
+    <link rel="stylesheet prefetch" href="static/common.css">
   </head>
   <body>
     <div class="vib-header">


### PR DESCRIPTION
As explained here https://www.mapbox.com/blog/introducing-geojson-vt/

MapboxGL JS uses geojson-vt behind the scene. So no extra work is needed.
I added support to drag and drop `LineString` geojson.

A zipped file can be found in data folder (which you'll need to unzip first)

As always, perfs are pretty amazing with a 32.3 MB geojson file.

@stebie 
Shall I do the same for ol?